### PR TITLE
Update to latest Android version, add new onAttach() lifecycle callba…

### DIFF
--- a/tools/LifecycleLog/app/build.gradle
+++ b/tools/LifecycleLog/app/build.gradle
@@ -1,23 +1,23 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.3"
 
     defaultConfig {
         applicationId "com.example.lifecyclelog"
-        minSdkVersion 8
-        targetSdkVersion 19
+        minSdkVersion 9
+        targetSdkVersion 24
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:20.+'
+    compile 'com.android.support:support-v4:24.2.1'
 }

--- a/tools/LifecycleLog/app/src/main/java/com/example/lifecyclelog/TestFragment.java
+++ b/tools/LifecycleLog/app/src/main/java/com/example/lifecyclelog/TestFragment.java
@@ -3,6 +3,7 @@ package com.example.lifecyclelog;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
@@ -14,7 +15,7 @@ import static com.example.lifecyclelog.Util.LifecycleState.CALL_TO_SUPER;
 import static com.example.lifecyclelog.Util.LifecycleState.RETURN_FROM_SUPER;
 import static com.example.lifecyclelog.Util.recLifeCycle;
 
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@TargetApi(Build.VERSION_CODES.M)
 public class TestFragment extends Fragment {
 
     @Override
@@ -50,11 +51,34 @@ public class TestFragment extends Fragment {
 
     }
 
+    @TargetApi(Build.VERSION_CODES.M)
+    @Override
+    public void onAttach(Context context) {
+        recLifeCycle(getClass(), CALL_TO_SUPER);
+        super.onAttach(context);
+        recLifeCycle(getClass(), RETURN_FROM_SUPER);
+        commonOnAttach(getActivity());
+    }
+
+    /*
+     * Deprecated on API 23
+     * Use onAttachToContext instead
+     */
+    @SuppressWarnings("deprecation")
     @Override
     public void onAttach(Activity activity) {
         recLifeCycle(getClass(), CALL_TO_SUPER);
         super.onAttach(activity);
         recLifeCycle(getClass(), RETURN_FROM_SUPER);
+
+        // Prevent double call - Android M calls both onAttach() lifecycle functions for backward compatibility
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            commonOnAttach(activity);
+        }
+    }
+
+    private void commonOnAttach(Activity activity) {
+        // Do some stuff for attach.
     }
 
     @Override

--- a/tools/LifecycleLog/app/src/main/res/layout/activity_main_compat.xml
+++ b/tools/LifecycleLog/app/src/main/res/layout/activity_main_compat.xml
@@ -9,8 +9,9 @@
     tools:context=".MainActivity" >
 
     <fragment android:id="@+id/test_fragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.example.lifecyclelog.TestCompatFragment" />
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              class="com.example.lifecyclelog.TestCompatFragment"
+              tools:layout="@layout/fragment_test"/>
 
 </RelativeLayout>

--- a/tools/LifecycleLog/build.gradle
+++ b/tools/LifecycleLog/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 


### PR DESCRIPTION
…ck in fragment

Android M deprecated the onAttach(Activity) callback and introduced the new onAttach(Context) callback.
To be backward compatible Android M and above calls _both_ lifecycle functions which may lead to some
unwanted double initializations etc. The output of the logcat clearly shows this.

 The new code in TestFragment class deals with this.

I updated your really useful tool to run with the Android M version and probably also Android N. 
